### PR TITLE
fix: report manager not openning report correctly and update unit test

### DIFF
--- a/src/__tests__/core/report-manager.test.js
+++ b/src/__tests__/core/report-manager.test.js
@@ -10,9 +10,9 @@ jest.mock('../../utils/logger', () => ({
 }));
 
 // Mock generate-report module
-jest.mock('../../utils/generate-report', () => {
-  return jest.fn().mockReturnValue('Mock report content');
-});
+jest.mock('../../utils/generate-report', () => ({
+  generateReport: jest.fn().mockReturnValue('Mock report content')
+}));
 
 // Mock config manager before requiring report manager
 jest.mock('../../config/config-manager', () => {

--- a/src/core/report-manager.js
+++ b/src/core/report-manager.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { exec } = require("child_process");
 const { logInfo } = require("../utils/logger");
-const generateReport = require("../utils/generate-report");
+const { generateReport } = require("../utils/generate-report");
 const configManager = require("../config/config-manager");
 
 class ReportManager {


### PR DESCRIPTION
# Fix Report Generation and Test Suite

## Changes
- Fixed the import of `generateReport` in `report-manager.js` to correctly destructure the function from the module
- Updated the test mocks in `report-manager.test.js` to match the actual module structure

## Problem
The report was not being generated and opened automatically after the scan due to an incorrect import statement. The `generateReport` function was being imported as a module instead of being destructured from the module's exports.

## Solution
- Changed the import statement from `const generateReport = require("../utils/generate-report")` to `const { generateReport } = require("../utils/generate-report")`
- Updated the test mocks to properly simulate the module's structure with `generateReport` as a property

## Impact
- Users will now see their scan reports open automatically in their default browser
- The test suite correctly validates the report generation functionality