### PR TITLE
feat: add GitHub Actions workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test (Node.js ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Run tests
+      run: npm test
+    
+    - name: Run test coverage
+      run: npm run test:coverage
+      
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage/
+        retention-days: 7 


### PR DESCRIPTION
# Add GitHub Actions Workflow for Automated Testing

## Changes
- Added GitHub Actions workflow to run Jest tests automatically
- Workflow triggers on:
  - Pull requests to main
  - Pushes to main branch
- Includes test coverage reporting and artifact upload

## Notes
- Uses Node.js 18.x
- Runs `npm test` and `npm run test:coverage`
- Coverage reports are retained for 7 days